### PR TITLE
add razor alias to cshtml for Razor page files

### DIFF
--- a/src/languages/cshtml.js
+++ b/src/languages/cshtml.js
@@ -368,6 +368,7 @@ function(hljs) {
 
     return {
         subLanguage: 'xml',
+        aliases: ['razor'],
         contains: [
             hljs.COMMENT("@\\*", "\\*@"),
             EXCEPTIONS,

--- a/test/api/getLanguage.js
+++ b/test/api/getLanguage.js
@@ -10,6 +10,13 @@ describe('.getLanguage()', function() {
     result.should.be.instanceOf(Object);
   });
 
+  it('should get the cshtml language by razor alias', function() {
+    const result = hljs.getLanguage('razor');
+
+    result.should.be.instanceOf(Object);
+    result.should.have.property('aliases').with.containEql('cshtml');
+  });
+
   it('should be case insensitive', function() {
     const result = hljs.getLanguage('pYTHOn');
 


### PR DESCRIPTION
Small change to the cshtml language definition to allow ```razor instead of ```cshtml . This is to better support in the ASP.NET Core reference docset w/o breaking CSHTML tags in other places and duplicating the highlighting definition in its own file.