### PR TITLE
Add CSHTML support for @addTagHelper, @implements, and @namespace

### DIFF
--- a/src/languages/cshtml.js
+++ b/src/languages/cshtml.js
@@ -28,14 +28,14 @@ function(hljs) {
     };
 
     var DIRECTIVES = {
-        begin: "^@(addTagHelper|implements|inherits|inject|model|namespace|using)[^\\r\\n{\\(]*$",
+        begin: "^@(addTagHelper|attribute|implements|inherits|inject|model|namespace|using)[^\\r\\n{\\(]*$",
         end: "$",
         className: SPECIAL_SYMBOL_CLASSNAME,
         returnBegin: true,
         returnEnd: true,
         contains: [
             {
-                begin: "@(addTagHelper|implements|inherits|inject|model|namespace|using)",
+                begin: "@(addTagHelper|attribute|implements|inherits|inject|model|namespace|using)",
                 className: SPECIAL_SYMBOL_CLASSNAME,
             },
             {

--- a/src/languages/cshtml.js
+++ b/src/languages/cshtml.js
@@ -10,7 +10,7 @@ function(hljs) {
 
     var BLOCK_TEXT = {
         begin: "[@]{0,1}<text>",
-        returnBegin: true,  
+        returnBegin: true,
         end: "</text>",
         returnEnd: true,
         subLanguage: "cshtml",
@@ -28,14 +28,14 @@ function(hljs) {
     };
 
     var DIRECTIVES = {
-        begin: "^@(model|using|inherits|inject)[^\\r\\n{\\(]*$",
+        begin: "^@(addTagHelper|implements|inherits|inject|model|namespace|using)[^\\r\\n{\\(]*$",
         end: "$",
         className: SPECIAL_SYMBOL_CLASSNAME,
         returnBegin: true,
         returnEnd: true,
-        contains: [ 
+        contains: [
             {
-                begin: "@(model|using|inherits|inject)",
+                begin: "@(addTagHelper|implements|inherits|inject|model|namespace|using)",
                 className: SPECIAL_SYMBOL_CLASSNAME,
             },
             {
@@ -60,7 +60,7 @@ function(hljs) {
             { begin: "[a-zA-Z]+@" },
         ],
         skip: true
-    }
+    };
 
     var ONE_LINE_EXPRESSION = {
         begin: "@[a-zA-Z]+",
@@ -152,8 +152,6 @@ function(hljs) {
         ],
     };
 
-    
-
     var BUILT_IN_CODE_BLOCKS_VARIANTS = [
         {
             begin: "@for[\\s]*\\([^{]+[\\s]*{",
@@ -184,6 +182,7 @@ function(hljs) {
             end: "}"
         },
     ];
+
     var BUILT_IN_CODE_BLOCKS = {
         variants: BUILT_IN_CODE_BLOCKS_VARIANTS,
         returnBegin: true,
@@ -256,7 +255,6 @@ function(hljs) {
         ]
     };
 
-
     var BLOCK_TRY = {
         begin: "@try[\\s]*{",
         end: "}",
@@ -317,7 +315,6 @@ function(hljs) {
         ]
     };
 
-
     var BLOCK_FUNCTIONS = {
         begin: "@functions[\\s]*{",
         end: "}",
@@ -364,7 +361,7 @@ function(hljs) {
                 endsParent: true
             }
         ]
-    }
+    };
 
     return {
         subLanguage: 'xml',

--- a/test/detect/cshtml/default.txt
+++ b/test/detect/cshtml/default.txt
@@ -3,6 +3,7 @@
 @model Person
 @namespace RazorPagesContacts.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@attribute [Authorize]
 
 @{
     ViewData["Title"] = "Bootstrap Editors";

--- a/test/detect/cshtml/default.txt
+++ b/test/detect/cshtml/default.txt
@@ -1,4 +1,8 @@
+@implements IDisposable
+@using RazorPagesIntro.Pages
 @model Person
+@namespace RazorPagesContacts.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 
 @{
     ViewData["Title"] = "Bootstrap Editors";


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore.Docs/issues/16955

Modify the CSHTML language definition to support the following directives in *.cshtml files:

- `@addTagHelper`
- `@attribute`
- `@implements`
- `@namespace`

The local test run (via `node tools/build.js -n cshtml`) shows proper coloring being applied to the directives:

![image](https://user-images.githubusercontent.com/10702007/74284603-ac4c6480-4ce9-11ea-9128-b928b46bb8a4.png)
